### PR TITLE
Fix React import error

### DIFF
--- a/docs/docs/0.42/integration-with-existing-apps.md
+++ b/docs/docs/0.42/integration-with-existing-apps.md
@@ -297,7 +297,7 @@ $ touch index.ios.js
 ```js
 'use strict';
 
-import React from 'react';
+import React,{Component} from 'react';
 import {
   AppRegistry,
   StyleSheet,


### PR DESCRIPTION
In react-native V0.42.0, this line of 'import React from 'react' ', should replaced by 'import React,{Component} from 'react''. This test OK!