### PR TITLE
Update style.md

### DIFF
--- a/docs/docs/0.51/style.md
+++ b/docs/docs/0.51/style.md
@@ -8,7 +8,7 @@
 import React, { Component } from 'react';
 import { AppRegistry, StyleSheet, Text, View } from 'react-native';
 
-class LotsOfStyles extends Component {
+export default class LotsOfStyles extends Component {
   render() {
     return (
       <View>


### PR DESCRIPTION
export default class LotsOfStyles extends Component

原有程序模块没有默认导出LotsOfStyle，会导致程序报错。

英文原版为修改后这句。