### PR TITLE
the name of method change

### DIFF
--- a/docs/docs/0.51/integration-with-existing-apps.md
+++ b/docs/docs/0.51/integration-with-existing-apps.md
@@ -671,7 +671,7 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
         mReactInstanceManager = ReactInstanceManager.builder()
                 .setApplication(getApplication())
                 .setBundleAssetName("index.android.bundle")
-                .setJSMainModuleName("index.android")
+                .setJSMainModulePath("index.android")
                 .addPackage(new MainReactPackage())
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.RESUMED)


### PR DESCRIPTION
在 [v0.49.0-rc.0](https://github.com/facebook/react-native/blob/v0.49.0-rc.0/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java) 及以后的版本，方法变更：setJSMainModuleName => setJSMainModulePath